### PR TITLE
"match_weight" -> "match_probability" in histogram

### DIFF
--- a/deduplication_detailed_example.ipynb
+++ b/deduplication_detailed_example.ipynb
@@ -4190,7 +4190,7 @@
    ],
    "source": [
     "from splink.diagnostics import splink_score_histogram\n",
-    "splink_score_histogram(df_e, spark, 100, \"match_weight\", symmetric=True)"
+    "splink_score_histogram(df_e, spark, 100, \"match_probability\", symmetric=True)"
    ]
   },
   {


### PR DESCRIPTION
The text just above this cell talks about inspecting the match probability, so the call to the histogram should plot the probability rather than weight